### PR TITLE
feat: point opusclip badge to api and update label

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -5,8 +5,8 @@
 &nbsp;
 
 [![opus.pro](https://img.shields.io/badge/%F0%9F%8C%90%20opus.pro-6723FF?style=for-the-badge)](https://www.opus.pro)
-[![Try OpusClip](https://img.shields.io/badge/%F0%9F%8E%AC%20Try%20OpusClip-238636?style=for-the-badge)](https://www.opus.pro)
-[![AgentOpus](https://img.shields.io/badge/%F0%9F%A4%96%20AgentOpus-BE717B?style=for-the-badge)](https://www.opus.pro)
+[![OpusClip API](https://img.shields.io/badge/%F0%9F%8E%AC%20Try%20OpusClip-238636?style=for-the-badge)](https://www.opus.pro/api)
+[![AgentOpus](https://img.shields.io/badge/%F0%9F%A4%96%20AgentOpus-BE717B?style=for-the-badge)](https://www.opus.pro/agent)
 [![Hiring](https://img.shields.io/badge/%F0%9F%92%BC%20We're%20hiring-D29922?style=for-the-badge)](https://jobs.ashbyhq.com/opusclip)
 
 </div>

--- a/profile/README.md
+++ b/profile/README.md
@@ -5,7 +5,7 @@
 &nbsp;
 
 [![opus.pro](https://img.shields.io/badge/%F0%9F%8C%90%20opus.pro-6723FF?style=for-the-badge)](https://www.opus.pro)
-[![OpusClip API](https://img.shields.io/badge/%F0%9F%8E%AC%20Try%20OpusClip-238636?style=for-the-badge)](https://www.opus.pro/api)
+[![OpusClip API](https://img.shields.io/badge/%F0%9F%8E%AC%20OpusClip%20API-238636?style=for-the-badge)](https://www.opus.pro/api)
 [![AgentOpus](https://img.shields.io/badge/%F0%9F%A4%96%20AgentOpus-BE717B?style=for-the-badge)](https://www.opus.pro/agent)
 [![Hiring](https://img.shields.io/badge/%F0%9F%92%BC%20We're%20hiring-D29922?style=for-the-badge)](https://jobs.ashbyhq.com/opusclip)
 


### PR DESCRIPTION
## What

Updates the OpusClip badge in the org profile README so the rendered badge, alt text, and link are consistent. The previous commit repointed the link to `https://www.opus.pro/api` and changed the alt text to "OpusClip API", but the shields.io image still encoded "🎬 Try OpusClip". This PR updates the badge image text to "🎬 OpusClip API" so all three agree.

## Changes

- `feat: update document link` — repoint Try OpusClip → `/api` and AgentOpus → `/agent`.
- `feat: update badge text to match OpusClip API link` — badge label `Try OpusClip` → `OpusClip API`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)