### PR TITLE
ci: keep public repo gates on hosted runners

### DIFF
--- a/.github/workflows/actions-pinned-check.yml
+++ b/.github/workflows/actions-pinned-check.yml
@@ -13,11 +13,15 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read # actions/checkout needs this to fetch a private repo
+  contents: read # actions/checkout
 
 jobs:
   check:
-    runs-on: opus-runner-standard
+    # This repo is public, so the gate must stay on a hosted runner: a fork PR
+    # runs untrusted code, and self-hosted runners would execute it on our own
+    # infrastructure. The check is shell-only and needs nothing a hosted runner
+    # lacks. https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/manage-access#self-hosted-runner-security-with-public-repositories
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:

--- a/.github/workflows/check-pr-basic.yml
+++ b/.github/workflows/check-pr-basic.yml
@@ -22,4 +22,6 @@ jobs:
       - uses: thehanimo/pr-title-checker@1d8cd483a2b73118406a187f54dca8a9415f1375 # v1.4.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          configuration_path: pull_request_title.json
+          # The config lives in this repo, so read it off the checkout above
+          # rather than through the contents API, which this job cannot reach.
+          local_configuration_path: pull_request_title.json


### PR DESCRIPTION
## What & why

This repo is public. Two of its gates were broken by assumptions that only hold for our private repos.

**1. `actions-pinned-check` never ran.** The job declared `runs-on: opus-runner-standard`, a self-hosted runner. It has never once been assigned a runner in this repo — every run sat queued with `runner_name=""` until GitHub auto-cancelled it at the 24h ceiling ([run 31613024589](https://github.com/opus-pro/.github/actions/runs/31613024589), [run 31847701356](https://github.com/opus-pro/.github/actions/runs/31847701356)). The identical gate finished in 8 seconds when it ran on `ubuntu-latest` ([run 31595196968](https://github.com/opus-pro/.github/actions/runs/31595196968)).

Beyond the hang, a public repo should not target self-hosted runners at all: a pull request from a fork runs untrusted code, and a self-hosted runner would execute it on our own infrastructure with whatever state the previous job left behind. This is [GitHub's documented guidance](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/manage-access#self-hosted-runner-security-with-public-repositories). The gate is shell-only — a `grep` over `.github/**` — so it needs nothing a hosted runner lacks.

**2. `check-pr-basics` failed on every PR.** `thehanimo/pr-title-checker` was fetching `pull_request_title.json` through the GitHub contents API, which this job cannot reach. The file lives in this repo and the job already checks it out, so `local_configuration_path` reads the same config straight off the working tree. `LABEL.name` is empty in the config, which short-circuits the action's label calls, so that fetch was its only API call — the gate is now self-contained.

Verified locally against this branch: the pinned-actions grep reports all `uses:` refs SHA-pinned, and `test_pr_title.py` passes.

## AI coding brief

- **Original request:** Get the `check` gate running on this repo — it had been queuing for 24h and dying without executing a step — and keep the public repo off self-hosted runners.
- **Manual interventions:** An earlier attempt routed the gate through a shared composite action while keeping the self-hosted runner; that was reverted (#10 closed) once it was clear the runner, not the gate's implementation, was the problem.
- **Retro:** "The check is failing" and "the check never started" look identical in the PR UI but have nothing in common — reading `runner_name` and the queued→cancelled timestamps off the jobs API separates them in one call and would have skipped the first attempt entirely. Worth stating a repo's visibility up front too: public vs private is what made both of these defaults wrong.
